### PR TITLE
chore: fix wrong model name

### DIFF
--- a/TheBloke-Chinese-Llama-2-13B-GGUF.json
+++ b/TheBloke-Chinese-Llama-2-13B-GGUF.json
@@ -44,7 +44,7 @@
       "name": "chinese-llama-2-13b.Q5_K_M.gguf",
       "quantMethod": "Q5_K_M",
       "bits": 5,
-      "size": 39410000000,
+      "size": 9410000000,
       "maxRamRequired": 11910000000,
       "usecase": "large, very low quality loss - recommended",
       "downloadLink": "https://huggingface.co/TheBloke/Chinese-Llama-2-13B-GGUF/resolve/main/chinese-llama-2-13b.Q5_K_M.gguf"

--- a/TheBloke-Mistral-7B-Instruct-v0.1-GGUF.json
+++ b/TheBloke-Mistral-7B-Instruct-v0.1-GGUF.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "mistral-7b-instruct-v0.1.Q5_K_S.gguf",
-      "quantMethod": "Q5",
+      "quantMethod": "Q5_K_S",
       "bits": 5,
       "size": 5000000000,
       "maxRamRequired": 7500000000,
@@ -50,7 +50,7 @@
       "downloadLink": "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q5_K_S.gguf"
     },
     {
-      "name": "mistral-7b-instruct-v0.1.Q5_K_S.gguf",
+      "name": "mistral-7b-instruct-v0.1.Q6_K.gguf",
       "quantMethod": "Q6_K",
       "bits": 6,
       "size": 5940000000,


### PR DESCRIPTION
## Problem
There are 2 versions of `mistral-7b-instruct-v0.1.Q5_K_S.gguf` that cause the error in app