### PR TITLE
chore: make param optional

### DIFF
--- a/.github/workflows/create-model-yml.yml
+++ b/.github/workflows/create-model-yml.yml
@@ -14,7 +14,6 @@ on:
         default: "8b"
       prompt_template:
         description: "Prompt template for the model"
-        required: true
         type: string
         default: |
           <|im_start|>system
@@ -24,7 +23,6 @@ on:
           <|im_start|>assistant
       stop_tokens:
         description: "Stop tokens for the model (comma-separated, e.g., <|im_end|>,</s>)"
-        required: true
         type: string
         default: "<|im_end|>"
       engine:


### PR DESCRIPTION
This pull request includes minor changes to the `.github/workflows/create-model-yml.yml` file. The changes involve removing the `required: true` attribute from the `prompt_template` and `stop_tokens` fields.

Changes in `.github/workflows/create-model-yml.yml`:

* Removed the `required: true` attribute from the `prompt_template` field.
* Removed the `required: true` attribute from the `stop_tokens` field.