### PR TITLE
feat: add convert llava gguf ci

### DIFF
--- a/.github/workflows/convert-llava-gguf.yml
+++ b/.github/workflows/convert-llava-gguf.yml
@@ -1,0 +1,202 @@
+name: Convert LLaVA model to GGUF
+
+on:
+  workflow_dispatch:
+    inputs:
+      llava_model_id:
+        description: 'Source LLaVA model ID on HuggingFace (e.g., liuhaotian/llava-v1.6-mistral-7b)'
+        required: true
+        type: string
+      llava_version:
+        description: 'LLaVA version (e.g., 1.5 or 1.6)'
+        required: true
+        type: string
+      target_model_id:
+        description: 'Target repository name on HuggingFace (e.g., llava)'
+        required: true
+        type: string
+      quant_levels:
+        description: 'Quantization levels to generate (comma-separated, e.g., f16,q4-km,q5-k-m,q8-0)'
+        required: true
+        type: string
+
+jobs:
+  converter:
+    runs-on: ubuntu-20-04-gguf
+    timeout-minutes: 7200
+    steps:
+      - name: Checkout llama.cpp repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          repository: ggml-org/llama.cpp
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Cache Python packages
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.local/share/pip
+            .venv
+          key: ${{ runner.os }}-pip-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip3 install -r requirements.txt
+          pip3 install -r examples/llava/requirements.txt
+          pip3 install hf-transfer
+          pip3 install torch
+          git lfs install
+
+      - name: Extract MODEL_NAME
+        run: |
+          MODEL_NAME="$(echo ${{ github.event.inputs.llava_model_id }} | rev | cut -d/ -f1 | rev)"
+          echo $MODEL_NAME
+          MODEL_NAME="$(echo $MODEL_NAME | tr '[:upper:]' '[:lower:]')"
+          echo $MODEL_NAME
+          echo "MODEL_NAME=$MODEL_NAME" >> $GITHUB_ENV
+
+      - name: Print environment variables
+        run: |
+          echo "USER_NAME: cortexso"
+          echo "LLAVA_MODEL_ID: ${{ github.event.inputs.llava_model_id }}"
+          echo "MODEL_NAME: ${{ env.MODEL_NAME }}"
+          echo "LLAVA_VERSION: ${{ github.event.inputs.llava_version }}"
+          echo "QUANT_LEVELS: ${{ github.event.inputs.quant_levels }}"
+
+      - name: Prepare folders
+        run: |
+          mkdir -p /mnt/models/${{ env.MODEL_NAME }}/hf
+          mkdir -p /mnt/models/${{ env.MODEL_NAME }}/vit
+          mkdir -p /mnt/models/.cache
+
+      - name: Download LLaVA model
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 15
+          max_attempts: 5
+          command: |
+            HF_HUB_ETAG_TIMEOUT=500 huggingface-cli download --repo-type model --local-dir /mnt/models/${{ env.MODEL_NAME }}/hf --cache-dir /mnt/models/.cache --token ${{ secrets.HUGGINGFACE_TOKEN_READ }} ${{ github.event.inputs.llava_model_id }}
+
+      - name: Perform LLaVA surgery
+        run: |
+          python ./examples/llava/llava_surgery_v2.py -C -m /mnt/models/${{ env.MODEL_NAME }}/hf
+          mkdir -p /mnt/models/${{ env.MODEL_NAME }}/vit
+          cp /mnt/models/${{ env.MODEL_NAME }}/hf/llava.clip /mnt/models/${{ env.MODEL_NAME }}/vit/pytorch_model.bin
+          cp /mnt/models/${{ env.MODEL_NAME }}/hf/llava.projector /mnt/models/${{ env.MODEL_NAME }}/vit/
+          # Download config for ViT
+          curl -s -q https://huggingface.co/cmp-nct/llava-1.6-gguf/raw/main/config_vit.json -o /mnt/models/${{ env.MODEL_NAME }}/vit/config.json
+
+      - name: Convert image encoder to GGUF
+        run: |
+          # For LLaVA 1.6, use the surgery output directly
+          python ./examples/llava/convert_image_encoder_to_gguf.py -m /mnt/models/${{ env.MODEL_NAME }}/vit --llava-projector /mnt/models/${{ env.MODEL_NAME }}/vit/llava.projector --output-dir /mnt/models/${{ env.MODEL_NAME }}/vit --clip-model-is-vision
+
+      - name: Build llama.cpp
+        run: |
+          cmake -B build
+          cmake --build build --config Release
+
+      - name: Convert LLaMA part to GGUF
+        run: |
+          python ./examples/convert_legacy_llama.py /mnt/models/${{ env.MODEL_NAME }}/hf --skip-unknown || (
+            echo "Legacy conversion failed, trying HF conversion method..."
+            # If legacy conversion fails, try converting using the HF converter
+            python ./convert_hf_to_gguf.py /mnt/models/${{ env.MODEL_NAME }}/hf --outfile /mnt/models/${{ env.MODEL_NAME }}/hf/ggml-model-f16.gguf
+          )
+          
+          # List files to see what was created
+          echo "Listing files in the output directory:"
+          ls -la /mnt/models/${{ env.MODEL_NAME }}/hf/
+          
+          # Find the gguf file and copy it to the expected name if needed
+          GGUF_FILE=$(find /mnt/models/${{ env.MODEL_NAME }}/hf/ -name "*.gguf" | head -n 1)
+          if [ -n "$GGUF_FILE" ] && [ "$GGUF_FILE" != "/mnt/models/${{ env.MODEL_NAME }}/hf/ggml-model-f16.gguf" ]; then
+            echo "Found GGUF file at $GGUF_FILE, copying to expected location"
+            cp "$GGUF_FILE" /mnt/models/${{ env.MODEL_NAME }}/hf/ggml-model-f16.gguf
+          fi
+
+      - name: Quantize the model
+        run: |
+          # Set appropriate paths for LLaVA
+          MMPROJ_PATH="/mnt/models/${{ env.MODEL_NAME }}/vit/mmproj-model-f16.gguf"
+          
+          mkdir -p /mnt/models/${{ env.MODEL_NAME }}/gguf/
+
+          # Create F16 model always
+          mkdir -p /mnt/models/${{ env.MODEL_NAME }}/gguf/f16/
+          cp /mnt/models/${{ env.MODEL_NAME }}/hf/ggml-model-f16.gguf /mnt/models/${{ env.MODEL_NAME }}/gguf/f16/model.gguf
+          cp ${MMPROJ_PATH} /mnt/models/${{ env.MODEL_NAME }}/gguf/f16/mmproj.gguf
+          
+          # Parse the quantization levels and create each one
+          IFS=',' read -ra QUANT_ARRAY <<< "${{ github.event.inputs.quant_levels }}"
+          for QUANT in "${QUANT_ARRAY[@]}"; do
+            if [ "$QUANT" != "f16" ]; then  # Skip f16 as we already created it
+              QUANT_DIR=$(echo "$QUANT" | tr '[:upper:]' '[:lower:]')
+              QUANT_TYPE=$(echo "$QUANT" | tr 'a-z-' 'A-Z_')  # Convert q4-km to Q4_K_M
+              
+              echo "Creating quantization: $QUANT_DIR using type $QUANT_TYPE"
+              mkdir -p /mnt/models/${{ env.MODEL_NAME }}/gguf/$QUANT_DIR/
+              ./build/bin/llama-quantize /mnt/models/${{ env.MODEL_NAME }}/hf/ggml-model-f16.gguf /mnt/models/${{ env.MODEL_NAME }}/gguf/$QUANT_DIR/model.gguf $QUANT_TYPE
+              cp ${MMPROJ_PATH} /mnt/models/${{ env.MODEL_NAME }}/gguf/$QUANT_DIR/mmproj.gguf
+            fi
+          done
+
+      - name: Upload to Hugging Face (quantization branches)
+        run: |
+          huggingface-cli login --token ${{ secrets.HUGGINGFACE_TOKEN_WRITE }} --add-to-git-credential
+          
+          # Upload f16 model always
+          huggingface-cli upload "cortexso/${{ github.event.inputs.target_model_id }}" "/mnt/models/${{ env.MODEL_NAME }}/gguf/f16/" . --revision "gguf-f16"
+          
+          # Upload each quantization level as a separate branch
+          IFS=',' read -ra QUANT_ARRAY <<< "${{ github.event.inputs.quant_levels }}"
+          for QUANT in "${QUANT_ARRAY[@]}"; do
+            if [ "$QUANT" != "f16" ]; then  # Skip f16 as we already uploaded it
+              QUANT_DIR=$(echo "$QUANT" | tr '[:upper:]' '[:lower:]')
+              echo "Uploading quantization: $QUANT_DIR"
+              huggingface-cli upload "cortexso/${{ github.event.inputs.target_model_id }}" "/mnt/models/${{ env.MODEL_NAME }}/gguf/$QUANT_DIR/" . --revision "gguf-$QUANT_DIR"
+            fi
+          done
+
+      - name: Upload to Hugging Face (main branch)
+        run: |
+          # Create a temporary directory for renamed files
+          mkdir -p /mnt/models/${{ env.MODEL_NAME }}/gguf/main
+
+          # Copy mmproj file
+          MMPROJ_PATH="/mnt/models/${{ env.MODEL_NAME }}/vit/mmproj-model-f16.gguf"
+          cp ${MMPROJ_PATH} /mnt/models/${{ env.MODEL_NAME }}/gguf/main/mmproj-model-f16.gguf
+
+          # Copy and rename all quantization levels for the main branch
+          cp "/mnt/models/${{ env.MODEL_NAME }}/gguf/f16/model.gguf" \
+             "/mnt/models/${{ env.MODEL_NAME }}/gguf/main/${{ env.MODEL_NAME }}-f16.gguf"
+          
+          # Copy each quantization level with proper naming
+          IFS=',' read -ra QUANT_ARRAY <<< "${{ github.event.inputs.quant_levels }}"
+          for QUANT in "${QUANT_ARRAY[@]}"; do
+            if [ "$QUANT" != "f16" ]; then  # Skip f16 as we already copied it
+              QUANT_DIR=$(echo "$QUANT" | tr '[:upper:]' '[:lower:]')
+              QUANT_TYPE=$(echo "$QUANT" | tr '-' '_')  # Convert q4-km to q4_km for filename
+              
+              echo "Copying quantization for main branch: $QUANT_DIR as $QUANT_TYPE"
+              cp "/mnt/models/${{ env.MODEL_NAME }}/gguf/$QUANT_DIR/model.gguf" \
+                 "/mnt/models/${{ env.MODEL_NAME }}/gguf/main/${{ env.MODEL_NAME }}-$QUANT_TYPE.gguf"
+            fi
+          done
+
+          # Upload to main branch
+          huggingface-cli upload "cortexso/${{ github.event.inputs.target_model_id }}" \
+                                "/mnt/models/${{ env.MODEL_NAME }}/gguf/main/" \
+                                . \
+                                --revision "main"
+
+          # Cleanup
+          huggingface-cli logout


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for converting LLaVA models to the GGUF format. The workflow is designed to automate the conversion process, including downloading the model, performing necessary transformations, and uploading the results to Hugging Face.

Key changes include:

* **Workflow Setup:**
  * Added a new workflow file `.github/workflows/convert-llava-gguf.yml` to define the conversion process.
  * Configured the workflow to trigger manually using `workflow_dispatch` with required inputs such as `llava_model_id`, `llava_version`, `target_model_id`, and `quant_levels`.

* **Job Configuration:**
  * Defined a job named `converter` that runs on `ubuntu-20-04-gguf` and includes a series of steps to perform the conversion.
  * Set up necessary environment, including checking out the repository, setting up Python, and caching Python packages.

* **Model Conversion:**
  * Implemented steps to download the LLaVA model, perform model surgery, convert the image encoder and LLaMA parts to GGUF, and quantize the model at different levels.
  * Included error handling to attempt alternative conversion methods if the initial attempt fails. (