### PR TITLE
fix: cache version deprecated

### DIFF
--- a/.github/workflows/convert-llava-gguf.yml
+++ b/.github/workflows/convert-llava-gguf.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.12'
 
       - name: Cache Python packages
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip

--- a/.github/workflows/convert-model-all-quant.yml
+++ b/.github/workflows/convert-model-all-quant.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: '3.12'
 
       - name: Cache Python packages
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip


### PR DESCRIPTION
This pull request includes updates to the caching mechanism in two GitHub workflow files to use the latest version of the `actions/cache` action.

Updates to caching mechanism:

* [`.github/workflows/convert-llava-gguf.yml`](diffhunk://#diff-0700e8eb15011cffa5a75bfbeea868dc0a46c38966a94c75a47b1f88f28812a5L40-R40): Updated the `actions/cache` action from a specific commit to version `v4`.
* [`.github/workflows/convert-model-all-quant.yml`](diffhunk://#diff-cce9696054f59c128b5ffec250ad923172767293702d3da335829a102907de21L47-R47): Updated the `actions/cache` action from a specific commit to version `v4`.